### PR TITLE
Allow rust version to be specified by $RUST_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 * Cached `multirust`, Rust toolchain.
 * Caching of previous build artifacts to (potentially dramatically) speed up
 similar builds.
-* Configurable version selection inside of the `Cargo.toml`.
+* Configurable version selection inside of the `Cargo.toml`, or by specifying the `$RUST_VERSION` environment variable.
 
 ## Configuration
 

--- a/bin/compile
+++ b/bin/compile
@@ -48,7 +48,12 @@ export PATH="$PATH:$CACHE_DIR/multirust/bin"
 export MULTIRUST_HOME="$CACHE_DIR/.multirust"
 
 # Use Multirust
-MULTIRUST_VERSION="$(cat $BUILD_DIR/Cargo.toml | grep -ohzP "(?<=\[target.heroku\])[^\[]*" | grep -ohzP "(?<=version = \")[^\"]*")" || true
+if [ -n "$RUST_VERSION" ]; then
+  MULTIRUST_VERSION="$RUST_VERSION"
+else
+  MULTIRUST_VERSION="$(cat $BUILD_DIR/Cargo.toml | grep -ohzP "(?<=\[target.heroku\])[^\[]*" | grep -ohzP "(?<=version = \")[^\"]*")" || true
+fi
+
 if [[ -z "$MULTIRUST_VERSION" ]]; then
     log "Setting version to \"nightly\" (default)"
     multirust default "nightly"

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -36,6 +36,8 @@ cleanup()
     rm -rf $BUILD_DIR
     rm -rf $CACHE_DIR
     rm -rf /tmp/multirust-repo
+
+    unset RUST_VERSION
 }
 
 testDefault()
@@ -109,6 +111,22 @@ EOF
 
     assertCaptured "-----> Fetching multirust"
     assertCaptured "-----> Setting version to \"stable\""
+    assertCaptured "-----> No cached crates detected"
+    assertCaptured "-----> Compiling application"
+    assertCaptured "-----> Caching build artifacts"
+
+    cleanup
+}
+
+testVersionEnvironmentOverride()
+{
+    setup
+
+    export RUST_VERSION=nightly-2016-04-15
+    compile
+
+    assertCaptured "-----> Fetching multirust"
+    assertCaptured "-----> Setting version to \"nightly-2016-04-15\""
     assertCaptured "-----> No cached crates detected"
     assertCaptured "-----> Compiling application"
     assertCaptured "-----> Caching build artifacts"


### PR DESCRIPTION
As discussed in #16.

`$RUST_VERSION` takes precedence over `target.heroku` in Cargo.toml. 
