### PR TITLE
Do not make use of cached deps (#24)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 sudo: false
 language: bash
 
-addons:
-    apt:
-        packages:
-            - svn
 env:
     - SHUNIT_HOME="/tmp/shunit2/source/2.1"
 
 before_install:
     - git clone https://github.com/heroku/heroku-buildpack-testrunner.git /tmp/testrunner
     - git clone https://github.com/smtlaissezfaire/shunit2 /tmp/shunit2
+    - chmod +x /tmp/shunit2/source/2.1/src/shunit2
 script: /tmp/testrunner/bin/run -c .

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ env:
 
 before_install:
     - git clone https://github.com/heroku/heroku-buildpack-testrunner.git /tmp/testrunner
-    - svn checkout http://shunit2.googlecode.com/svn/trunk/ /tmp/shunit2
+    - git clone https://github.com/smtlaissezfaire/shunit2 /tmp/shunit2
 script: /tmp/testrunner/bin/run -c .

--- a/bin/compile
+++ b/bin/compile
@@ -64,19 +64,13 @@ else
     multirust update "$MULTIRUST_VERSION"
 fi
 
-# Change into correct directory.
+# Change into correct directory
 cd "$BUILD_DIR"
-
-if [[ ! -d "$CACHE_DIR/target" ]]; then
-    log "No cached crates detected"
-else
-    log "Detected cached crates... Restoring..."
-    mv "$CACHE_DIR/target" "$BUILD_DIR/target"
-fi
 
 # Build the Rust app
 log "Compiling application..."
 CARGO_HOME="$CACHE_DIR/cargo" cargo build --release
 
-log "Caching build artifacts"
-cp -r "$BUILD_DIR/target" "$CACHE_DIR/target"
+# Remove the cache
+log "Deleting target/release/deps..."
+rm -r "target/release/deps"

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -56,7 +56,7 @@ testDefault()
 
     assertCaptured "-----> Pre-existing multirust"
     assertCaptured "multirust: using existing install for"
-    assertCaptured "-----> Detected cached crates... Restoring..."
+    assertCaptured "-----> Deleting target/release/deps..."
 
     cleanup
 }


### PR DESCRIPTION
Solve #24 by not using any caching system on dependencies (285MB -> 10.8MB).

As discussed, this is not the best way, but at least I can deploy now \o/

Additionally, it seems Heroku does not try to download everything again:

``````
-----> Rust app detected

-----> Pre-existing multirust

-----> Setting version to "stable"

multirust: using existing install for 'stable'

multirust: default toolchain set to 'stable'

multirust: updating existing install for 'stable'

rustup: gpg available. signatures will be verified

rustup: downloading manifest for 'stable'

rustup: downloading toolchain for 'stable'

rustup: 'stable' is already up to date

-----> Compiling application...

   Compiling unicode-normalization v0.1.2

   Compiling lazy_static v0.1.16```
``````
