### PR TITLE
Replace multirust with rustup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,10 @@
 
 **Features:**
 
-* Cached `multirust`, Rust toolchain.
-* Caching of previous build artifacts to (potentially dramatically) speed up
-similar builds.
-* Configurable version selection inside of the `Cargo.toml`, or by specifying the `$RUST_VERSION` environment variable.
+* Cached [rustup.sh](https://rustup.rs), the Rust toolchain installer.
+* Configurable Rust version selection inside of the `Cargo.toml`, or by specifying the `$RUST_VERSION` environment variable.
 
 ## Configuration
-
-You can use any override you would pass `multirust` for this buildpack.
 
 We currently (ab)use the `cargo`'s "target" feature to set the version desired.
 Unfortunately because of this there are sometimes (harmless) `cargo` warnings

--- a/bin/compile
+++ b/bin/compile
@@ -31,45 +31,49 @@ log() {
     echo "-----> $1"
 }
 
-# Install multirust
-if [[ ! -d "$CACHE_DIR/multirust" ]]; then
-    log "Fetching multirust..."
-    git clone --recursive https://github.com/brson/multirust /tmp/multirust-repo
-    cd /tmp/multirust-repo
-    git submodule update --init
-    ./build.sh
-    ./install.sh --destdir="$CACHE_DIR/multirust" --prefix=""
-else
-    log "Pre-existing multirust"
-fi
-export PATH="$PATH:$CACHE_DIR/multirust/bin"
+# rust-lang-nursery/rustup.rs#618
+exec_cmd() {
+    CARGO_HOME="$CACHE_DIR/.cargo" RUSTUP_HOME="$CACHE_DIR/.rustup" bash -c "$1"
+}
 
-# Change where `multirust` places it's `.multirust` dir from the default `$HOME/.multirust`
-export MULTIRUST_HOME="$CACHE_DIR/.multirust"
-
-# Use Multirust
+# Select the Rust version
 if [ -n "$RUST_VERSION" ]; then
-  MULTIRUST_VERSION="$RUST_VERSION"
+    RUSTUP_VERSION="$RUST_VERSION"
 else
-  MULTIRUST_VERSION="$(cat $BUILD_DIR/Cargo.toml | grep -ohzP "(?<=\[target.heroku\])[^\[]*" | grep -ohzP "(?<=version = \")[^\"]*")" || true
+    RUSTUP_VERSION="$(cat $BUILD_DIR/Cargo.toml | grep -ohzP "(?<=\[target.heroku\])[^\[]*" | grep -ohzP "(?<=version = \")[^\"]*")" || true
 fi
 
-if [[ -z "$MULTIRUST_VERSION" ]]; then
-    log "Setting version to \"nightly\" (default)"
-    multirust default "nightly"
-    multirust update "nightly"
+# Install rustup.sh
+if [[ ! -d "$CACHE_DIR/.rustup" ]]; then
+    log "Fetching rustup.sh..."
+    exec_cmd "curl https://sh.rustup.rs -sSf | sh -s -- -y"
 else
-    log "Setting version to \"$MULTIRUST_VERSION\""
-    multirust default "$MULTIRUST_VERSION"
-    multirust update "$MULTIRUST_VERSION"
+    log "Pre-existing rustup.sh"
 fi
+
+# Add rustup.sh binaries to $PATH
+export PATH="$PATH:$CACHE_DIR/.cargo/bin"
+
+if [[ -z "$RUSTUP_VERSION" ]]; then
+    log "Setting version to \"nightly\" (default)"
+    exec_cmd "rustup install nightly"
+    exec_cmd "rustup default nightly"
+else
+    log "Setting version to \"$RUSTUP_VERSION\""
+    exec_cmd "rustup install \"$RUSTUP_VERSION\""
+    exec_cmd "rustup default \"$RUSTUP_VERSION\""
+fi
+
+# Check if there are updates
+log "Updating rustup.sh..."
+exec_cmd "rustup update"
 
 # Change into correct directory
 cd "$BUILD_DIR"
 
 # Build the Rust app
 log "Compiling application..."
-CARGO_HOME="$CACHE_DIR/cargo" cargo build --release
+exec_cmd "cargo build --release"
 
 # Remove the cache
 log "Deleting target/release/deps..."

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -35,7 +35,6 @@ cleanup()
 {
     rm -rf $BUILD_DIR
     rm -rf $CACHE_DIR
-    rm -rf /tmp/multirust-repo
 
     unset RUST_VERSION
 }
@@ -46,16 +45,19 @@ testDefault()
 
     compile
 
-    assertCaptured "-----> Fetching multirust"
+    assertCaptured "-----> Fetching rustup.sh..."
     assertCaptured "-----> Setting version to \"nightly\" (default)"
-    assertCaptured "-----> No cached crates detected"
-    assertCaptured "-----> Compiling application"
-    assertCaptured "-----> Caching build artifacts"
+    assertCaptured "info: checking for self-updates"
+    assertCaptured "-----> Compiling application..."
+    assertCaptured "-----> Deleting target/release/deps..."
 
     compile
 
-    assertCaptured "-----> Pre-existing multirust"
-    assertCaptured "multirust: using existing install for"
+    assertCaptured "-----> Pre-existing rustup.sh"
+    assertCaptured "info: using existing install for 'stable-x86_64-unknown-linux-gnu'"
+    assertCaptured "info: default toolchain set to 'stable-x86_64-unknown-linux-gnu'"
+    assertCaptured "info: checking for self-updates"
+    assertCaptured "-----> Compiling application..."
     assertCaptured "-----> Deleting target/release/deps..."
 
     cleanup
@@ -71,11 +73,11 @@ EOF
 
     compile
 
-    assertCaptured "-----> Fetching multirust"
+    assertCaptured "-----> Fetching rustup.sh..."
     assertCaptured "-----> Setting version to \"nightly\""
-    assertCaptured "-----> No cached crates detected"
-    assertCaptured "-----> Compiling application"
-    assertCaptured "-----> Caching build artifacts"
+    assertCaptured "info: checking for self-updates"
+    assertCaptured "-----> Compiling application..."
+    assertCaptured "-----> Deleting target/release/deps..."
 
     cleanup
 }
@@ -90,11 +92,11 @@ EOF
 
     compile
 
-    assertCaptured "-----> Fetching multirust"
-    assertCaptured "-----> Setting version to \"beta\""
-    assertCaptured "-----> No cached crates detected"
-    assertCaptured "-----> Compiling application"
-    assertCaptured "-----> Caching build artifacts"
+    assertCaptured "-----> Fetching rustup.sh..."
+    assertCaptured "-----> Setting version to \"stable\""
+    assertCaptured "info: checking for self-updates"
+    assertCaptured "-----> Compiling application..."
+    assertCaptured "-----> Deleting target/release/deps..."
 
     cleanup
 }


### PR DESCRIPTION
This PR aims to solve #21. Both rustup.sh and cargo will be installed in cached folders in case they are not installed yet. At every deploy we run `rustup update` to update rustup.sh itself and Rust to the latest versions, whether they're present.

Unfortunately I had problems running most of the rustup.sh commands without explicitly passing our ENV variables to them (and this is why I had to wrap every rustup.sh command inside `cmd_exec()`) – local variables and exported variables didn't work for me :(
